### PR TITLE
Optimize anilist feed request loading

### DIFF
--- a/frontend/src/app/feed/feed.component.html
+++ b/frontend/src/app/feed/feed.component.html
@@ -134,7 +134,7 @@
                         <span
                           *ngIf="activity.likeCount > 0"
                           style="cursor: pointer"
-                          (click)="toggleLikers('activity', activity.id)"
+                          (click)="toggleLikers('activity', activity.id, undefined)"
                           class="user-select-none"
                         >
                           {{ activity.likeCount }}
@@ -220,7 +220,7 @@
                                 <span
                                   *ngIf="reply.likeCount > 0"
                                   style="cursor: pointer"
-                                  (click)="toggleLikers('reply', reply.id)"
+                                  (click)="toggleLikers('reply', reply.id, activity.id)"
                                   class="user-select-none"
                                 >
                                   {{ reply.likeCount }}

--- a/frontend/src/app/services/anilist.service.ts
+++ b/frontend/src/app/services/anilist.service.ts
@@ -189,6 +189,18 @@ export class AnilistService {
     return this.anilistFeed.postReply(activityId, text);
   }
 
+  async loadActivityLikes(activityId: number): Promise<boolean> {
+    return this.anilistFeed.loadActivityLikes(activityId);
+  }
+
+  async loadActivityReplies(activityId: number): Promise<boolean> {
+    return this.anilistFeed.loadActivityReplies(activityId);
+  }
+
+  async loadReplyLikes(activityId: number, replyId: number): Promise<boolean> {
+    return this.anilistFeed.loadReplyLikes(activityId, replyId);
+  }
+
   get feed() {
     return this.anilistFeed.feed;
   }


### PR DESCRIPTION
Implement lazy loading for activity likes and replies to reduce initial Anilist API request size.

The Anilist API was experiencing issues with overly extensive feed requests. This change optimizes the initial feed load by only fetching like and reply counts, deferring the retrieval of detailed like and reply data until the user explicitly interacts with those elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-e77f357d-ee65-4356-9ab4-d526526d98bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e77f357d-ee65-4356-9ab4-d526526d98bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

