### PR TITLE
fix: Shikimori domain change to `.io`

### DIFF
--- a/backend/app/Providers/ShikimoriServiceProvider.php
+++ b/backend/app/Providers/ShikimoriServiceProvider.php
@@ -22,9 +22,9 @@ class ShikimoriServiceProvider extends ServiceProvider
             'clientId' => env('SHIKIMORI_CLIENT_ID'),
             'clientSecret' => env('SHIKIMORI_CLIENT_SECRET'),
             'redirectUri' => env('APP_URL') . '/shikimori/auth',
-            'urlAuthorize' => 'https://shikimori.one/oauth/authorize',
-            'urlAccessToken' => 'https://shikimori.one/oauth/token',
-            'urlResourceOwnerDetails' => 'https://shikimori.one/api/users/whoami',
+            'urlAuthorize' => 'https://shikimori.io/oauth/authorize',
+            'urlAccessToken' => 'https://shikimori.io/oauth/token',
+            'urlResourceOwnerDetails' => 'https://shikimori.io/api/users/whoami',
             // Add HTTP client options with custom User-Agent
             'httpClient' => [
                 'headers' => [

--- a/frontend/src/app/anime/details/details.component.html
+++ b/frontend/src/app/anime/details/details.component.html
@@ -365,7 +365,7 @@
                     <myanili-icon-shikimori></myanili-icon-shikimori>
                     <a
                       class="ms-1"
-                      [href]="'https://shikimori.one/animes/' + anime.id"
+                      [href]="'https://shikimori.io/animes/' + anime.id"
                       target="_blank"
                       >Shikimori</a
                     >

--- a/frontend/src/app/components/logins/shikimori-login/shikimori-login.component.html
+++ b/frontend/src/app/components/logins/shikimori-login/shikimori-login.component.html
@@ -3,7 +3,7 @@
   <div class="col-7">
     @if (shikimoriLoggedIn) {
       <myanili-icon-shikimori class="me-1"></myanili-icon-shikimori>
-      <a href="https://shikimori.one/{{ shikimoriLoggedIn.nickname }}" target="_blank">{{
+      <a href="https://shikimori.io/{{ shikimoriLoggedIn.nickname }}" target="_blank">{{
         shikimoriLoggedIn.nickname
       }}</a>
       <myanili-icon

--- a/frontend/src/app/manga/details/details.component.html
+++ b/frontend/src/app/manga/details/details.component.html
@@ -380,7 +380,7 @@
                       <myanili-icon-shikimori></myanili-icon-shikimori>
                       <a
                         class="ms-1"
-                        [href]="'https://shikimori.one/mangas/' + manga.id"
+                        [href]="'https://shikimori.io/mangas/' + manga.id"
                         target="_blank"
                         >Shikimori</a
                       >

--- a/frontend/src/app/services/shikimori.service.ts
+++ b/frontend/src/app/services/shikimori.service.ts
@@ -12,7 +12,7 @@ import { DialogueService } from './dialogue.service';
   providedIn: 'root',
 })
 export class ShikimoriService {
-  private readonly baseUrl = 'https://shikimori.one/api';
+  private readonly baseUrl = 'https://shikimori.io/api';
   private accessToken = '';
   private refreshToken = '';
   private userSubject = new BehaviorSubject<ShikimoriUser | undefined>(undefined);
@@ -24,7 +24,7 @@ export class ShikimoriService {
     this.refreshToken = String(localStorage.getItem('shikimoriRefreshToken') || '');
 
     this.client = new Client({
-      url: 'https://shikimori.one/api/graphql',
+      url: 'https://shikimori.io/api/graphql',
       preferGetMethod: false,
       fetchOptions: () => {
         return {


### PR DESCRIPTION
Shikimori now uses `.io` cc-TLD, resolving auth error.

There's no official announcement I could spot, but I got this announcement from [3rd party client's announcement](https://shikimori.io/clubs/1609-shikimori-android#comment-13014714) and another client commit: https://github.com/pewaru-333/ShikiApp/commit/d287e8be029528a47036b5f10565e591284f0afd