### PR TITLE
fix: replace Promise.all with Promise.allSettled for library update fan-outs (#114)

### DIFF
--- a/frontend/src/app/anime/details/details.component.ts
+++ b/frontend/src/app/anime/details/details.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Button } from '@components/dialogue/dialogue.component';
 import { StreamPipe } from '@components/stream.pipe';
+import { ToasterService } from '@components/toaster/toaster.service';
 import {
   Anime,
   AnimeEpisodeRule,
@@ -77,6 +78,7 @@ export class AnimeDetailsComponent implements OnInit {
     private cache: CacheService,
     private dialogue: DialogueService,
     private malService: MalService,
+    private toaster: ToasterService,
   ) {
     this.route.paramMap.subscribe(async params => {
       const newId = Number(params.get('id'));
@@ -437,7 +439,7 @@ export class AnimeDetailsComponent implements OnInit {
       }
     }
     data.extension = Base64.encode(JSON.stringify(this.anime.my_extension));
-    const [animeStatus] = await Promise.all([
+    const plusOneResults = await Promise.allSettled([
       this.animeService.updateAnime(
         {
           malId: this.anime.id,
@@ -460,6 +462,15 @@ export class AnimeDetailsComponent implements OnInit {
         currentEpisode + 1,
       ),
     ]);
+    const malPlusOneResult = plusOneResults[0];
+    if (malPlusOneResult.status === 'rejected') throw malPlusOneResult.reason;
+    if (plusOneResults[1].status === 'rejected') {
+      this.toaster.addError('Trakt scrobble failed. Please try again later.', 0);
+    }
+    if (plusOneResults[2].status === 'rejected') {
+      this.toaster.addError('SIMKL scrobble failed. Please try again later.', 0);
+    }
+    const animeStatus = malPlusOneResult.value;
     if (completed) {
       animeStatus.is_rewatching = false;
       const sequels = this.anime.related_anime.filter(

--- a/frontend/src/app/services/anilist/library.service.ts
+++ b/frontend/src/app/services/anilist/library.service.ts
@@ -98,13 +98,7 @@ export class AnilistLibraryService {
     `;
     data.mediaId = id;
     const variables = JSON.parse(JSON.stringify(data) || '{}');
-    return this.client
-      .mutation(QUERY, variables)
-      .toPromise()
-      .catch(error => {
-        console.log({ error });
-        return undefined;
-      });
+    return this.client.mutation(QUERY, variables).toPromise();
   }
 
   async getMediaListId(id: number): Promise<number | undefined> {
@@ -147,11 +141,7 @@ export class AnilistLibraryService {
     return this.client
       .mutation<{ DeleteMediaListEntry: { deleted: boolean } }>(QUERY, { id })
       .toPromise()
-      .then(result => ({ deleted: result.data?.DeleteMediaListEntry.deleted || false }))
-      .catch(error => {
-        console.log({ error });
-        return { deleted: false, msg: error.message };
-      });
+      .then(result => ({ deleted: result.data?.DeleteMediaListEntry.deleted || false }));
   }
 
   async getStatusMapping(malIds: number[], type: 'ANIME' | 'MANGA') {

--- a/frontend/src/app/services/anime/anime.service.ts
+++ b/frontend/src/app/services/anime/anime.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { ToasterService } from '@components/toaster/toaster.service';
 import { statusFromMal } from '@models/anilist';
 import {
   Anime,
@@ -34,6 +35,31 @@ import { LivechartService } from './livechart.service';
 })
 export class AnimeService {
   nsfw = true;
+
+  private readonly updateServiceNames = [
+    null,
+    'AniList',
+    'Kitsu',
+    'aniSearch',
+    'Shikimori',
+    'SIMKL',
+    'Annict',
+    'Trakt',
+    'Livechart',
+  ] as const;
+
+  private readonly deleteServiceNames = [
+    null,
+    'AniList',
+    'Kitsu',
+    'aniSearch',
+    'Shikimori',
+    'SIMKL',
+    'Annict',
+    'Trakt',
+    'Livechart',
+  ] as const;
+
   constructor(
     private malService: MalService,
     private anilist: AnilistService,
@@ -48,6 +74,7 @@ export class AnimeService {
     private settings: SettingsService,
     private dialogue: DialogueService,
     private glob: GlobalService,
+    private toaster: ToasterService,
   ) {
     this.settings.nsfw$.asObservable().subscribe(nsfw => {
       this.nsfw = nsfw;
@@ -185,7 +212,7 @@ export class AnimeService {
     },
     data: MyAnimeUpdateExtended,
   ): Promise<MyAnimeStatus> {
-    const [malResponse] = await Promise.all([
+    const results = await Promise.allSettled([
       this.malService.put<MyAnimeStatus>('anime/' + ids.malId, data),
       (async () => {
         if (this.anilist.loggedIn) {
@@ -256,7 +283,17 @@ export class AnimeService {
       this.trakt.updateEntry(ids.trakt, data),
       this.livechart.updateAnime(ids.livechartId, data),
     ]);
-    return malResponse;
+    const malResult = results[0];
+    if (malResult.status === 'rejected') throw malResult.reason;
+    for (let i = 1; i < results.length; i++) {
+      if (results[i].status === 'rejected') {
+        this.toaster.addError(
+          `${this.updateServiceNames[i]} update failed. Please try again later.`,
+          0,
+        );
+      }
+    }
+    return malResult.value;
   }
 
   async deleteAnime(ids: {
@@ -269,7 +306,7 @@ export class AnimeService {
     traktId?: string;
     livechartId?: number;
   }) {
-    await Promise.all([
+    const results = await Promise.allSettled([
       this.malService.delete<MyAnimeStatus>('anime/' + ids.malId),
       this.anilist.deleteEntry(ids.anilistId),
       this.kitsu.deleteEntry(ids.kitsuId, 'anime'),
@@ -280,6 +317,16 @@ export class AnimeService {
       this.trakt.drop(ids.traktId),
       this.livechart.deleteAnime(ids.livechartId),
     ]);
+    const malResult = results[0];
+    if (malResult.status === 'rejected') throw malResult.reason;
+    for (let i = 1; i < results.length; i++) {
+      if (results[i].status === 'rejected') {
+        this.toaster.addError(
+          `${this.deleteServiceNames[i]} delete failed. Please try again later.`,
+          0,
+        );
+      }
+    }
     return true;
   }
 

--- a/frontend/src/app/services/anime/annict.service.ts
+++ b/frontend/src/app/services/anime/annict.service.ts
@@ -213,33 +213,37 @@ export class AnnictService {
   async updateEntry(annictId?: number, data?: Partial<MyAnimeUpdate>) {
     if (!annictId || !this.accessToken) return;
     if (data?.num_watched_episodes) {
-      this.updateProgress(annictId, data?.num_watched_episodes);
+      await this.updateProgress(annictId, data?.num_watched_episodes);
     }
     if (data?.status) {
-      this.updateStatus(annictId, this.statusFromMal(data.status));
+      await this.updateStatus(annictId, this.statusFromMal(data.status));
     }
     if (data?.score) {
-      this.addRating(annictId, data.score);
+      await this.addRating(annictId, data.score);
     }
   }
 
   async updateStatus(annictId?: number, status?: AnnictStatus) {
     if (!annictId || !this.accessToken || !status) return;
-    await fetch(`${this.baseUrl}me/statuses?work_id=${annictId}&kind=${status}`, {
+    const response = await fetch(`${this.baseUrl}me/statuses?work_id=${annictId}&kind=${status}`, {
       method: 'POST',
       headers: this.getFetchHeader(),
     });
+    if (!response.ok) throw new Error(`Annict: HTTP ${response.status}`);
   }
 
   async updateProgress(annictId: number, episodeMin: number, episodeMax?: number) {
     if (!this.accessToken) return;
     const episodes = await this.getEpisodeIds(annictId, episodeMin, episodeMax);
-    for (const episode of episodes) {
-      fetch(`${this.baseUrl}me/records?episode_id=${episode}`, {
-        method: 'POST',
-        headers: this.getFetchHeader(),
-      });
-    }
+    await Promise.all(
+      episodes.map(async episode => {
+        const response = await fetch(`${this.baseUrl}me/records?episode_id=${episode}`, {
+          method: 'POST',
+          headers: this.getFetchHeader(),
+        });
+        if (!response.ok) throw new Error(`Annict: HTTP ${response.status}`);
+      }),
+    );
   }
 
   async addRating(annictId: number, rating: number) {
@@ -250,10 +254,11 @@ export class AnnictService {
       `${'★'.repeat(Math.max(0, rating))}${'☆'.repeat(Math.max(0, 10 - rating))}
       _rated on myani.li_`,
     );
-    fetch(
+    const response = await fetch(
       `${this.baseUrl}me/reviews?work_id=${annictId}&rating_overall_state=${annictRating}&body=${body}`,
       { method: 'POST', headers: this.getFetchHeader() },
     );
+    if (!response.ok) throw new Error(`Annict: HTTP ${response.status}`);
   }
 
   async getEpisodeIds(

--- a/frontend/src/app/services/anime/livechart.service.ts
+++ b/frontend/src/app/services/anime/livechart.service.ts
@@ -293,8 +293,7 @@ export class LivechartService {
       }>(MUTATION, { animeId: id, attributes })
       .toPromise();
     if (error || !data) {
-      console.log(error);
-      return;
+      throw new Error(`Livechart: ${error?.message ?? 'unknown error'}`);
     }
   }
 
@@ -337,8 +336,7 @@ export class LivechartService {
       }>(MUTATION, { animeId: id, attributes })
       .toPromise();
     if (error || !data) {
-      console.log(error);
-      return false;
+      throw new Error(`Livechart: ${error?.message ?? 'unknown error'}`);
     }
     return true;
   }

--- a/frontend/src/app/services/anime/simkl.service.ts
+++ b/frontend/src/app/services/anime/simkl.service.ts
@@ -110,7 +110,7 @@ export class SimklService {
   async scrobble(ids: { simkl?: number; mal?: number }, number?: number) {
     if (!this.clientId || !this.accessToken || (!ids.simkl && !ids.mal) || !number) return;
     const scrobbleData = { shows: [{ ids, seasons: [{ number: 1, episodes: [{ number }] }] }] };
-    return fetch(`${this.baseUrl}sync/history`, {
+    const response = await fetch(`${this.baseUrl}sync/history`, {
       method: 'POST',
       headers: new Headers({
         Authorization: `Bearer ${this.accessToken}`,
@@ -118,6 +118,8 @@ export class SimklService {
       }),
       body: JSON.stringify(scrobbleData),
     });
+    if (!response.ok) throw new Error(`SIMKL: HTTP ${response.status}`);
+    return response;
   }
 
   async updateEntry(ids: { simkl?: number; mal?: number }, data: Partial<MyAnimeUpdate>) {
@@ -138,7 +140,7 @@ export class SimklService {
   async addToList(ids: { simkl?: number; mal?: number }, list?: SimklList) {
     if (!this.clientId || !this.accessToken || (!ids.simkl && !ids.mal) || !list) return;
     const toListData = { shows: [{ to: list, ids }] };
-    return fetch(`${this.baseUrl}sync/add-to-list`, {
+    const response = await fetch(`${this.baseUrl}sync/add-to-list`, {
       method: 'POST',
       headers: new Headers({
         Authorization: `Bearer ${this.accessToken}`,
@@ -146,12 +148,14 @@ export class SimklService {
       }),
       body: JSON.stringify(toListData),
     });
+    if (!response.ok) throw new Error(`SIMKL: HTTP ${response.status}`);
+    return response;
   }
 
   async deleteEntry(id?: number) {
     if (!this.clientId || !this.accessToken || !id) return;
     const deleteData = { shows: [{ ids: { simkl: id } }] };
-    return fetch(`${this.baseUrl}sync/history/remove`, {
+    const response = await fetch(`${this.baseUrl}sync/history/remove`, {
       method: 'POST',
       headers: new Headers({
         Authorization: `Bearer ${this.accessToken}`,
@@ -159,12 +163,14 @@ export class SimklService {
       }),
       body: JSON.stringify(deleteData),
     });
+    if (!response.ok) throw new Error(`SIMKL: HTTP ${response.status}`);
+    return response;
   }
 
   async addRating(ids: { simkl?: number; mal?: number }, rating: number) {
     if (!this.clientId || !this.accessToken || (!ids.simkl && !ids.mal)) return;
     const ratingData = { shows: [{ rating, ids }] };
-    return fetch(`${this.baseUrl}sync/ratings`, {
+    const response = await fetch(`${this.baseUrl}sync/ratings`, {
       method: 'POST',
       headers: new Headers({
         Authorization: `Bearer ${this.accessToken}`,
@@ -172,6 +178,8 @@ export class SimklService {
       }),
       body: JSON.stringify(ratingData),
     });
+    if (!response.ok) throw new Error(`SIMKL: HTTP ${response.status}`);
+    return response;
   }
 
   async getRating(id?: number): Promise<ExtRating | undefined> {

--- a/frontend/src/app/services/anime/trakt.service.ts
+++ b/frontend/src/app/services/anime/trakt.service.ts
@@ -189,7 +189,8 @@ export class TraktService {
       method,
       body,
     });
-    return result.ok;
+    if (!result.ok) throw new Error(`Trakt: HTTP ${result.status}`);
+    return true;
   }
 
   async searchMovie(q: string): Promise<Show[]> {
@@ -294,10 +295,10 @@ export class TraktService {
   async updateEntry(trakt?: { id?: string; season?: number }, data?: Partial<MyAnimeUpdate>) {
     if (!trakt || !trakt.id || !this.accessToken) return;
     if (data?.status === 'dropped') {
-      this.drop(trakt.id);
+      await this.drop(trakt.id);
     }
     if (data?.score) {
-      this.addRating(data.score, trakt.id, trakt.season);
+      await this.addRating(data.score, trakt.id, trakt.season);
     }
   }
 
@@ -330,11 +331,12 @@ export class TraktService {
       data.shows = [];
       data.movies.push({ rating, ids: { slug } });
     }
-    this.fetch(`${this.baseUrl}sync/ratings`, {
+    const result = await this.fetch(`${this.baseUrl}sync/ratings`, {
       method: 'POST',
       headers,
       body: JSON.stringify(data),
     });
+    if (!result.ok) throw new Error(`Trakt: HTTP ${result.status}`);
   }
 
   logoff() {

--- a/frontend/src/app/services/anisearch.service.ts
+++ b/frontend/src/app/services/anisearch.service.ts
@@ -151,7 +151,7 @@ export class AnisearchService {
       if (!secondTry && response.status === 401 && (await this.refreshTokens())) {
         return this.deleteEntry(id, type, true);
       }
-      console.error('Failed to delete entry');
+      throw new Error(`aniSearch: HTTP ${response.status}`);
     }
   }
 
@@ -173,7 +173,7 @@ export class AnisearchService {
       if (!secondTry && response.status === 401 && (await this.refreshTokens())) {
         return this.updateEntry(id, data, type, true);
       }
-      console.error('Failed to update entry');
+      throw new Error(`aniSearch: HTTP ${response.status}`);
     }
   }
 

--- a/frontend/src/app/services/kitsu.service.ts
+++ b/frontend/src/app/services/kitsu.service.ts
@@ -297,11 +297,9 @@ export class KitsuService {
       }),
       body: JSON.stringify({ data }),
     });
-    if (result.ok) {
-      const { data: response } = (await result.json()) as KitsuResponse<KitsuEntry>;
-      return response;
-    }
-    return;
+    if (!result.ok) throw new Error(`Kitsu: HTTP ${result.status}`);
+    const { data: response } = (await result.json()) as KitsuResponse<KitsuEntry>;
+    return response;
   }
 
   async createEntry(
@@ -341,11 +339,9 @@ export class KitsuService {
         body: JSON.stringify({ data }),
       },
     );
-    if (result.ok) {
-      const { data: response } = (await result.json()) as KitsuResponse<KitsuEntry>;
-      return response;
-    }
-    return;
+    if (!result.ok) throw new Error(`Kitsu: HTTP ${result.status}`);
+    const { data: response } = (await result.json()) as KitsuResponse<KitsuEntry>;
+    return response;
   }
 
   async deleteEntry(
@@ -371,10 +367,8 @@ export class KitsuService {
         'Content-Type': 'application/vnd.api+json',
       }),
     });
-    if (result.ok) {
-      return true;
-    }
-    return false;
+    if (!result.ok) throw new Error(`Kitsu: HTTP ${result.status}`);
+    return true;
   }
 
   async getRating(id?: number, type: 'anime' | 'manga' = 'anime'): Promise<ExtRating | undefined> {

--- a/frontend/src/app/services/manga/manga.service.ts
+++ b/frontend/src/app/services/manga/manga.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { ToasterService } from '@components/toaster/toaster.service';
 import { statusFromMal } from '@models/anilist';
 import { RelatedAnime } from '@models/anime';
 import { Jikan4MangaCharacter, Jikan4WorkRelation } from '@models/jikan';
@@ -31,6 +32,25 @@ import { MangaupdatesService } from './mangaupdates.service';
   providedIn: 'root',
 })
 export class MangaService {
+  private readonly updateServiceNames = [
+    null,
+    'AniList',
+    'Kitsu',
+    'aniSearch',
+    'Shikimori',
+    'MangaUpdates',
+    'MangaBaka',
+  ] as const;
+
+  private readonly deleteServiceNames = [
+    null,
+    'AniList',
+    'Kitsu',
+    'aniSearch',
+    'Shikimori',
+    'MangaBaka',
+  ] as const;
+
   constructor(
     private malService: MalService,
     private anilist: AnilistService,
@@ -41,6 +61,7 @@ export class MangaService {
     // @ts-ignore
     private mangabaka: MangabakaService,
     private cache: CacheService,
+    private toaster: ToasterService,
   ) {}
 
   async list(status?: ReadStatus, options?: { limit?: number; offset?: number }) {
@@ -108,7 +129,7 @@ export class MangaService {
     },
     data: MyMangaUpdateExtended,
   ): Promise<MyMangaStatus> {
-    const [malResponse] = await Promise.all([
+    const results = await Promise.allSettled([
       this.malService.put<MyMangaStatus>('manga/' + ids.malId, data),
       (async () => {
         if (this.anilist.loggedIn) {
@@ -193,30 +214,35 @@ export class MangaService {
         const state = data.is_rereading ? 'rereading' : this.mangabaka.statusFromMal(data.status);
         if (!state) return;
 
-        try {
-          // Build update object and filter out null/undefined values
-          const updates = {
-            state,
-            progress_chapter: data.num_chapters_read || null,
-            progress_volume: data.num_volumes_read || null,
-            rating: data.score ? Math.round(data.score * 10) : null,
-            start_date: data.start_date || null,
-            finish_date: data.finish_date || null,
-            number_of_rereads: data.num_times_reread || null,
-            note: data.comments || null,
-          };
-          // Remove null/undefined values before sending PATCH request
-          const filteredUpdates = Object.fromEntries(
-            Object.entries(updates).filter(([_, value]) => value != null),
-          );
-          return await this.mangabaka.updateLibraryEntry(ids.mangabakaId, filteredUpdates);
-        } catch (error) {
-          console.error('MangaBaka updateLibraryEntry error:', error);
-          return;
-        }
+        // Build update object and filter out null/undefined values
+        const updates = {
+          state,
+          progress_chapter: data.num_chapters_read || null,
+          progress_volume: data.num_volumes_read || null,
+          rating: data.score ? Math.round(data.score * 10) : null,
+          start_date: data.start_date || null,
+          finish_date: data.finish_date || null,
+          number_of_rereads: data.num_times_reread || null,
+          note: data.comments || null,
+        };
+        // Remove null/undefined values before sending PATCH request
+        const filteredUpdates = Object.fromEntries(
+          Object.entries(updates).filter(([_, value]) => value != null),
+        );
+        return await this.mangabaka.updateLibraryEntry(ids.mangabakaId, filteredUpdates);
       })(),
     ]);
-    return malResponse;
+    const malResult = results[0];
+    if (malResult.status === 'rejected') throw malResult.reason;
+    for (let i = 1; i < results.length; i++) {
+      if (results[i].status === 'rejected') {
+        this.toaster.addError(
+          `${this.updateServiceNames[i]} update failed. Please try again later.`,
+          0,
+        );
+      }
+    }
+    return malResult.value;
   }
 
   async deleteManga(ids: {
@@ -226,7 +252,7 @@ export class MangaService {
     anisearchId?: number;
     mangabakaId?: number;
   }) {
-    await Promise.all([
+    const results = await Promise.allSettled([
       this.malService.delete<boolean>('manga/' + ids.malId),
       this.anilist.deleteEntry(ids.anilistId),
       this.kitsu.deleteEntry(ids.kitsuId, 'manga'),
@@ -234,14 +260,19 @@ export class MangaService {
       this.shikimori.deleteMedia(ids.malId, 'Manga'),
       (async () => {
         if (!ids.mangabakaId) return;
-        try {
-          return await this.mangabaka.removeFromLibrary(ids.mangabakaId);
-        } catch (error) {
-          console.error('MangaBaka removeFromLibrary error:', error);
-          return;
-        }
+        return await this.mangabaka.removeFromLibrary(ids.mangabakaId);
       })(),
     ]);
+    const malResult = results[0];
+    if (malResult.status === 'rejected') throw malResult.reason;
+    for (let i = 1; i < results.length; i++) {
+      if (results[i].status === 'rejected') {
+        this.toaster.addError(
+          `${this.deleteServiceNames[i]} delete failed. Please try again later.`,
+          0,
+        );
+      }
+    }
     return true;
   }
 

--- a/frontend/src/app/services/manga/mangabaka.service.ts
+++ b/frontend/src/app/services/manga/mangabaka.service.ts
@@ -315,7 +315,7 @@ export class MangabakaService {
       return true;
     } catch (error) {
       console.error('MangaBaka removeFromLibrary error:', error);
-      return false;
+      throw error;
     }
   }
 

--- a/frontend/src/app/services/manga/mangaupdates.service.ts
+++ b/frontend/src/app/services/manga/mangaupdates.service.ts
@@ -147,7 +147,7 @@ export class MangaupdatesService {
     data: { chapters?: number; volumes?: number; list?: ListType; rating?: number },
   ) {
     if (!id) return;
-    if (data.rating) this.addRating(id, data.rating);
+    if (data.rating) await this.addRating(id, data.rating);
     const updateData = {
       series: { id },
     } as {
@@ -169,7 +169,7 @@ export class MangaupdatesService {
           'Content-Type': 'application/json',
         }),
       });
-      if (!listsResponse.ok) return;
+      if (!listsResponse.ok) throw new Error(`MangaUpdates: HTTP ${listsResponse.status}`);
       this.myLists = (await listsResponse.json()) as BakaList[];
     }
     const newList = this.myLists.find(list => list.type === data.list);
@@ -185,7 +185,7 @@ export class MangaupdatesService {
     });
     if (updateResponse.ok) return;
 
-    await fetch(`${this.baseUrl}lists/series`, {
+    const createResponse = await fetch(`${this.baseUrl}lists/series`, {
       method: 'POST',
       headers: new Headers({
         Authorization: `Bearer ${this.accessToken}`,
@@ -193,10 +193,11 @@ export class MangaupdatesService {
       }),
       body: JSON.stringify([updateData]),
     });
+    if (!createResponse.ok) throw new Error(`MangaUpdates: HTTP ${createResponse.status}`);
   }
 
   async addRating(id: number, rating: number) {
-    await fetch(`${this.baseUrl}series/${id}/rating`, {
+    const response = await fetch(`${this.baseUrl}series/${id}/rating`, {
       method: 'PUT',
       headers: new Headers({
         Authorization: `Bearer ${this.accessToken}`,
@@ -204,6 +205,7 @@ export class MangaupdatesService {
       }),
       body: JSON.stringify({ rating }),
     });
+    if (!response.ok) throw new Error(`MangaUpdates: HTTP ${response.status}`);
   }
 
   statusFromMal(malStatus?: ReadStatus): ListType | undefined {

--- a/frontend/src/app/services/shikimori.service.ts
+++ b/frontend/src/app/services/shikimori.service.ts
@@ -184,8 +184,7 @@ export class ShikimoriService {
       body: JSON.stringify(data),
     });
     if (!response.ok) {
-      console.log(response);
-      return;
+      throw new Error(`Shikimori: HTTP ${response.status}`);
     }
     const result = await response.json();
     return result;
@@ -203,8 +202,7 @@ export class ShikimoriService {
     headers.append('Authorization', `Bearer ${this.accessToken}`);
     const response = await fetch(getUrl, { headers });
     if (!response.ok) {
-      console.log(response);
-      return;
+      throw new Error(`Shikimori: HTTP ${response.status}`);
     }
     const result = await response.json();
     if (!result[0]) return;
@@ -214,8 +212,7 @@ export class ShikimoriService {
       headers,
     });
     if (!deleteResponse.ok) {
-      console.log(deleteResponse);
-      return;
+      throw new Error(`Shikimori: HTTP ${deleteResponse.status}`);
     }
     return true;
   }


### PR DESCRIPTION
## Summary

Fixes #114. When a library update is sent to multiple external tracking services, a failure in one service no longer aborts all others or surfaces as an unrelated error to the user.

**Two-part change:**

- All external tracking services (AniList, Kitsu, aniSearch, Shikimori, SIMKL, Annict, Trakt, Livechart, MangaUpdates, MangaBaka) now **throw on HTTP failures** instead of silently swallowing errors. Guard returns (not logged in, no external ID) remain silent.
- `updateAnime()`, `deleteAnime()`, `updateManga()`, `deleteManga()` now use **`Promise.allSettled`**: MAL errors re-throw (preserving existing edit modal error flow), all other service failures show a **persistent toaster notification** — e.g. *"AniList update failed. Please try again later."*
- `plusOne()` in `AnimeDetailsComponent` also switched to `Promise.allSettled` for its local `[updateAnime, scrobbleTrakt, simkl.scrobble]` fan-out.

## Notable service fixes

| Service | Change |
|---|---|
| **Annict** | `updateEntry()` now awaits sub-calls; `updateProgress`/`addRating`/`updateStatus` no longer fire-and-forget |
| **Trakt** | `updateEntry()` awaits `drop()`/`addRating()`; `addRating()` was entirely fire-and-forget |
| **SIMKL** | `scrobble`, `addToList`, `addRating`, `deleteEntry` all check HTTP status |
| **AniList** | `.catch()` blocks removed — urql errors now propagate |
| **MangaBaka** | `removeFromLibrary()` re-throws instead of returning `false` |

## Test plan

- [ ] Update an anime/manga entry → edit modal closes normally, MAL status updates correctly
- [ ] `plusOne()` → episode counter increments, all `my_list_status` fields write back correctly
- [ ] Simulate a non-MAL service failure → toaster error appears, MAL update still succeeds
- [ ] Simulate a MAL failure → edit modal shows HTTP error dialogue as before
- [ ] Delete an anime/manga entry → item removed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)